### PR TITLE
Adiciona testes do RequestProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log*
 package-lock.json
 /dist
+/coverage

--- a/package.json
+++ b/package.json
@@ -57,8 +57,10 @@
     "eslint": "^6.7.2",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-vue": "^6.2.2",
+    "flush-promises": "^1.0.2",
     "highlight.js": "^10.6.0",
     "react-is": "^16.13.1",
+    "regenerator-runtime": "^0.13.9",
     "rollup": "^1.29.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-terser": "^5.2.0",
@@ -123,7 +125,19 @@
     "not dead"
   ],
   "jest": {
-    "preset": "@vue/cli-plugin-unit-jest"
+    "preset": "@vue/cli-plugin-unit-jest",
+    "transform": {
+      ".*\\.(js)$": "babel-jest"
+    },
+    "setupFilesAfterEnv": ["./src/utils/setupTests.js"],
+    "collectCoverage": true,
+    "collectCoverageFrom": ["src/**/*.vue"],
+    "coverageReporters": ["lcov", "text"]
+  },
+  "babel": {
+    "presets": [
+      "@babel/preset-env"
+    ]
   },
   "bugs": {
     "url": "https://github.com/Sysvale/show/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/show",
-  "version": "0.1",
+  "version": "0.1.0",
   "description": "A set of components used at Sysvale",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/show",
-  "version": "0.0.2",
+  "version": "0.1",
   "description": "A set of components used at Sysvale",
   "repository": {
     "type": "git",

--- a/src/components/__tests__/RequestProvider.spec.js
+++ b/src/components/__tests__/RequestProvider.spec.js
@@ -1,24 +1,24 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
-import convertKeysToCamelCase from '../../utils/convertKeysToCamelCase';
 import convertKeysToSnakeCase from '../../utils/convertKeysToSnakeCase';
 import RequestProvider from '../RequestProvider.vue';
 
 const localVue = createLocalVue();
 
 const responseDataMock = {
-	message: 'success message',
+	'test message': 'success message',
 };
 
 const payloadMock = {
 	id: '1',
+	'test--value': 'test value',
 };
 
 const successfulServiceMock = jest.fn(() => Promise.resolve({
 	data: responseDataMock,
 }));
 const failedServiceMock = jest.fn(() => Promise.reject(Error('test error')));
-const payloadResolverMock = jest.fn((payload) => convertKeysToCamelCase(payload));
+const payloadResolverMock = jest.fn();
 const dataResolverMock = jest.fn((data) => convertKeysToSnakeCase(data));
 const successFeedbackResolverMock = jest.fn();
 const errorFeedbackResolverMock = jest.fn();
@@ -92,7 +92,7 @@ describe('Service', () => {
 
 		await flushPromises();
 
-		expect(successfulServiceMock).toHaveBeenCalledWith(payloadMock);
+		expect(successfulServiceMock).toHaveBeenCalledWith(dataResolverMock(payloadMock));
 	});
 });
 
@@ -134,6 +134,7 @@ describe('Event', () => {
 
 describe('Resolvers', () => {
 	test('have their results applied correctly to payload and data', async () => {
+		expect.assertions(3);
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
@@ -152,8 +153,6 @@ describe('Resolvers', () => {
 		expect(payloadResolverMock).toHaveBeenCalledWith(payloadMock);
 
 		await flushPromises();
-
-		expect(wrapper.vm.payload).toStrictEqual(convertKeysToCamelCase(payloadMock));
 
 		expect(dataResolverMock).toHaveBeenCalledWith(responseDataMock);
 

--- a/src/components/__tests__/RequestProvider.spec.js
+++ b/src/components/__tests__/RequestProvider.spec.js
@@ -38,3 +38,263 @@ test('Component renders correctly', async () => {
 
 	expect(wrapper).toMatchSnapshot();
 });
+
+describe('Service', () => {
+	test('is called on mount if immediate is true', async () => {
+		expect.assertions(2);
+		mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: successfulServiceMock,
+				immediate: false,
+			},
+		});
+
+		await flushPromises();
+
+		expect(successfulServiceMock).not.toHaveBeenCalled();
+
+		mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: successfulServiceMock,
+				immediate: true,
+			},
+		});
+
+		await flushPromises();
+
+		expect(successfulServiceMock).toHaveBeenCalled();
+	});
+
+	test('is called correctly when action is triggered manually', async () => {
+		expect.assertions(1);
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: successfulServiceMock,
+			},
+		});
+
+		await flushPromises();
+
+		wrapper.vm.action(payloadMock);
+
+		await flushPromises();
+
+		expect(successfulServiceMock).toHaveBeenCalledWith(payloadMock);
+	});
+});
+
+describe('Event', () => {
+	test('is emitted correctly when a request has succeeded', async () => {
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: successfulServiceMock,
+				immediate: true,
+			},
+		});
+
+		await flushPromises();
+
+		expect(wrapper.emitted()).toHaveProperty('success');
+	});
+
+	test('is emitted correctly when a request has failed', async () => {
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: failedServiceMock,
+				immediate: true,
+			},
+		});
+
+		await flushPromises();
+
+		expect(wrapper.emitted()).toHaveProperty('error');
+	});
+});
+
+describe('Resolvers', () => {
+	test('have their results applied correctly to payload and data', async () => {
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: successfulServiceMock,
+				payloadResolver: payloadResolverMock,
+				dataResolver: dataResolverMock,
+				showSuccessFeedback: false,
+				payload: payloadMock,
+				immediate: true,
+			},
+		});
+
+		expect(payloadResolverMock).toHaveBeenCalledWith(payloadMock);
+
+		await flushPromises();
+
+		expect(wrapper.vm.payload).toStrictEqual(convertKeysToCamelCase(payloadMock));
+
+		expect(dataResolverMock).toHaveBeenCalledWith(responseDataMock);
+
+		await flushPromises();
+
+		expect(wrapper.vm.data).toStrictEqual(convertKeysToSnakeCase(responseDataMock));
+	});
+
+	test('are called correctly when a request has succeeded and showSuccessFeedback is false', async () => {
+		expect.assertions(4);
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: successfulServiceMock,
+				payloadResolver: payloadResolverMock,
+				dataResolver: dataResolverMock,
+				successFeedbackResolver: successFeedbackResolverMock,
+				showSuccessFeedback: false,
+				payload: payloadMock,
+				immediate: true,
+			},
+		});
+
+		expect(payloadResolverMock).toHaveBeenCalledWith(payloadMock);
+
+		await flushPromises();
+
+		expect(dataResolverMock).toHaveBeenCalledWith(responseDataMock);
+		expect(wrapper.emitted()).toHaveProperty('success');
+		expect(successFeedbackResolverMock).not.toHaveBeenCalled();
+	});
+
+	test('are called correctly when a request has succeeded and showSuccessFeedback is true', async () => {
+		expect.assertions(4);
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: successfulServiceMock,
+				payloadResolver: payloadResolverMock,
+				dataResolver: dataResolverMock,
+				successFeedbackResolver: successFeedbackResolverMock,
+				showSuccessFeedback: true,
+				payload: payloadMock,
+				immediate: true,
+			},
+		});
+
+		expect(payloadResolverMock).toHaveBeenCalledWith(payloadMock);
+
+		await flushPromises();
+
+		expect(dataResolverMock).toHaveBeenCalledWith(responseDataMock);
+		expect(wrapper.emitted()).toHaveProperty('success');
+		expect(successFeedbackResolverMock).toHaveBeenCalled();
+	});
+
+	test('are called correctly when a request has failed and hideErrorFeedback is true', async () => {
+		expect.assertions(4);
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: failedServiceMock,
+				payloadResolver: payloadResolverMock,
+				dataResolver: dataResolverMock,
+				errorFeedbackResolver: errorFeedbackResolverMock,
+				hideErrorFeedback: true,
+				payload: payloadMock,
+				immediate: true,
+			},
+		});
+
+		expect(payloadResolverMock).toHaveBeenCalledWith(payloadMock);
+
+		await flushPromises();
+
+		expect(dataResolverMock).toHaveBeenCalledWith(responseDataMock);
+		expect(wrapper.emitted()).toHaveProperty('error');
+		expect(errorFeedbackResolverMock).not.toHaveBeenCalled();
+	});
+
+	test('are called correctly when a request has failed and hideErrorFeedback is false', async () => {
+		expect.assertions(4);
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: failedServiceMock,
+				payloadResolver: payloadResolverMock,
+				dataResolver: dataResolverMock,
+				errorFeedbackResolver: errorFeedbackResolverMock,
+				hideErrorFeedback: false,
+				payload: payloadMock,
+				immediate: true,
+			},
+		});
+
+		expect(payloadResolverMock).toHaveBeenCalledWith(payloadMock);
+
+		await flushPromises();
+
+		expect(dataResolverMock).toHaveBeenCalledWith(responseDataMock);
+		expect(wrapper.emitted()).toHaveProperty('error');
+		expect(errorFeedbackResolverMock).toHaveBeenCalled();
+	});
+});
+
+describe('Error state', () => {
+	test('is reset after forceResetError is set to true', async () => {
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: '<div />',
+			},
+			propsData: {
+				service: failedServiceMock,
+				payload: payloadMock,
+				immediate: true,
+			},
+		});
+
+		await flushPromises();
+
+		expect(wrapper.emitted()).toHaveProperty('error');
+		expect(wrapper.vm.error).toBeTruthy();
+
+		wrapper.setProps({
+			forceResetError: true,
+		});
+
+		await flushPromises();
+
+		expect(wrapper.vm.error).toBeFalsy();
+	});
+});

--- a/src/components/__tests__/RequestProvider.spec.js
+++ b/src/components/__tests__/RequestProvider.spec.js
@@ -1,0 +1,26 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+
+import RequestProvider from '../RequestProvider.vue';
+
+const localVue = createLocalVue();
+
+const serviceMock = (payload) => Promise.resolve({
+	data: payload,
+});
+
+test('Component renders correctly', async () => {
+	const wrapper = mount(RequestProvider, {
+		localVue,
+		slots: {
+			default: '<div />',
+		},
+		propsData: {
+			service: serviceMock,
+		},
+	});
+
+	await flushPromises();
+
+	expect(wrapper).toMatchSnapshot();
+});

--- a/src/components/__tests__/RequestProvider.spec.js
+++ b/src/components/__tests__/RequestProvider.spec.js
@@ -1,13 +1,27 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
-
+import convertKeysToCamelCase from '../../utils/convertKeysToCamelCase';
+import convertKeysToSnakeCase from '../../utils/convertKeysToSnakeCase';
 import RequestProvider from '../RequestProvider.vue';
 
 const localVue = createLocalVue();
 
-const serviceMock = (payload) => Promise.resolve({
-	data: payload,
-});
+const responseDataMock = {
+	message: 'success message',
+};
+
+const payloadMock = {
+	id: '1',
+};
+
+const successfulServiceMock = jest.fn(() => Promise.resolve({
+	data: responseDataMock,
+}));
+const failedServiceMock = jest.fn(() => Promise.reject(Error('test error')));
+const payloadResolverMock = jest.fn((payload) => convertKeysToCamelCase(payload));
+const dataResolverMock = jest.fn((data) => convertKeysToSnakeCase(data));
+const successFeedbackResolverMock = jest.fn();
+const errorFeedbackResolverMock = jest.fn();
 
 test('Component renders correctly', async () => {
 	const wrapper = mount(RequestProvider, {
@@ -16,7 +30,7 @@ test('Component renders correctly', async () => {
 			default: '<div />',
 		},
 		propsData: {
-			service: serviceMock,
+			service: successfulServiceMock,
 		},
 	});
 

--- a/src/components/__tests__/RequestProvider.spec.js
+++ b/src/components/__tests__/RequestProvider.spec.js
@@ -22,12 +22,13 @@ const payloadResolverMock = jest.fn((payload) => convertKeysToCamelCase(payload)
 const dataResolverMock = jest.fn((data) => convertKeysToSnakeCase(data));
 const successFeedbackResolverMock = jest.fn();
 const errorFeedbackResolverMock = jest.fn();
+const defaultComponent = '<div />';
 
 test('Component renders correctly', async () => {
 	const wrapper = mount(RequestProvider, {
 		localVue,
 		slots: {
-			default: '<div />',
+			default: defaultComponent,
 		},
 		propsData: {
 			service: successfulServiceMock,
@@ -45,7 +46,7 @@ describe('Service', () => {
 		mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: successfulServiceMock,
@@ -60,7 +61,7 @@ describe('Service', () => {
 		mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: successfulServiceMock,
@@ -78,7 +79,7 @@ describe('Service', () => {
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: successfulServiceMock,
@@ -100,7 +101,7 @@ describe('Event', () => {
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: successfulServiceMock,
@@ -117,7 +118,7 @@ describe('Event', () => {
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: failedServiceMock,
@@ -136,7 +137,7 @@ describe('Resolvers', () => {
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: successfulServiceMock,
@@ -166,7 +167,7 @@ describe('Resolvers', () => {
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: successfulServiceMock,
@@ -193,7 +194,7 @@ describe('Resolvers', () => {
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: successfulServiceMock,
@@ -220,7 +221,7 @@ describe('Resolvers', () => {
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: failedServiceMock,
@@ -247,7 +248,7 @@ describe('Resolvers', () => {
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: failedServiceMock,
@@ -275,7 +276,7 @@ describe('Error state', () => {
 		const wrapper = mount(RequestProvider, {
 			localVue,
 			slots: {
-				default: '<div />',
+				default: defaultComponent,
 			},
 			propsData: {
 				service: failedServiceMock,
@@ -296,5 +297,29 @@ describe('Error state', () => {
 		await flushPromises();
 
 		expect(wrapper.vm.error).toBeFalsy();
+	});
+});
+
+describe('Label', () => {
+	test('changes correctly during request loading', async () => {
+		expect.assertions(2);
+
+		const wrapper = mount(RequestProvider, {
+			localVue,
+			slots: {
+				default: defaultComponent,
+			},
+			propsData: {
+				service: failedServiceMock,
+				payload: payloadMock,
+				immediate: true,
+			},
+		});
+
+		expect(wrapper.vm.labelHelper('test label')).toBe('Carregando...');
+
+		await flushPromises();
+
+		expect(wrapper.vm.labelHelper('test label')).toBe('test label');
 	});
 });

--- a/src/components/__tests__/__snapshots__/RequestProvider.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/RequestProvider.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component renders correctly 1`] = `<div></div>`;

--- a/src/utils/setupTests.js
+++ b/src/utils/setupTests.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'regenerator-runtime/runtime';


### PR DESCRIPTION
Configura ambiente de testes do projeto, além de criar testes para o componente RequestProvider

## Testando

- Execute `npm install`;
- Rode os testes unitários, utilizando o comando `npm run test:unit`;
- Verifique o código para se certificar de que todas as partes importantes do funcionamento do componente foram testadas corretamente;
- Deixe seu like e se inscreva no canal.