### PR TITLE
Adiciona prop renderless

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/show",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "A set of components used at Sysvale",
 	"repository": {
 		"type": "git",

--- a/src/components/RequestProvider.vue
+++ b/src/components/RequestProvider.vue
@@ -87,6 +87,10 @@ export default {
 		initialData: {
 			default: null,
 		},
+		renderless: {
+			type: Boolean,
+			default: false,
+		}
 	},
 
 	data() {
@@ -224,6 +228,10 @@ export default {
 				'Um erro aconteceu... por favor, tente novamente. Se o erro persistir, contate o suporte.',
 			),
 		});
+
+		if (this.renderless) {
+			return slot;
+		}
 
 		return h(this.tag, slot);
 	},


### PR DESCRIPTION
Adiciona prop `renderless` (quando true, essa prop não renderiza o wrapper definido na prop `tag `- que por padrão é uma div)


⚠️ O uso da prop `renderless `sobrescreve o uso da prop `tag`