### PR TITLE
Adiciona prop para resolver dados da resposta da requisiçÃo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/show",
-	"version": "1.4.1",
+	"version": "1.5.0",
 	"description": "A set of components used at Sysvale",
 	"repository": {
 		"type": "git",

--- a/src/components/RequestSelect.vue
+++ b/src/components/RequestSelect.vue
@@ -47,6 +47,10 @@ export default {
 			type: Function,
 			default: (item) => item,
 		},
+		responseResolver: {
+			type: Function,
+			default: (item) => item,
+		},
 		requestProviderOptions: {
 			type: Object,
 			default: () => ({
@@ -154,7 +158,7 @@ export default {
 
 	methods: {
 		handleSuccess(data = []) {
-			this.options = data.map((item) => {
+			this.options = this.responseResolver(data).map((item) => {
 				if(item instanceof Object) {
 					return {
 						...item,


### PR DESCRIPTION
Adiciona prop `responseResolver` no componente RequestSelect, para manipular a resposta da requisição de preenchimento de dados do select (funcionamento similar à prop `dataResolver` do RequestProvider).