### PR TITLE
Feature/show feature wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/show",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "A set of components used at Sysvale",
 	"repository": {
 		"type": "git",

--- a/src/components/FeatureWrapper.vue
+++ b/src/components/FeatureWrapper.vue
@@ -1,15 +1,12 @@
 <template>
-	<component
-		:is="computedComponent"
+	<template
+		v-if="mode !== 'hide'"
 	>
 		<slot
-			v-if="!isDisabled && mode !== 'hide'"
-			:disabled="isDisabled && mode === 'disable'
-		">
+			:disabled="isDisabled && mode === 'disable'"
+		>
 		</slot>
-	</component
-		
-	>
+	</template>
 </template>
 
 <script setup>
@@ -27,29 +24,7 @@ const { feature, mode, blockMessage } = defineProps({
 		default: 'hide',
 		validator: (value) => ['hide', 'disable', 'overlay'].includes(value),
 	},
-	blockMessage: {
-		type: String,
-		default: 'Essa funcionalidade está desabilitada.',
-	},
 });
 
 const isDisabled = computed(() => disabledFeatures.includes(feature));
-const computedComponent = computed(() => {
-	if (!isDisabled.value) {
-		return 'template';
-	}
-
-	switch (mode) {
-		case 'hide':
-			return 'template';
-		case 'overlay':
-			return 'cds-overlay';
-		default:
-			return 'template';
-	}
-});
 </script>
-
-<style lang="scss" scoped>
-/* Your component styles go here */
-</style>

--- a/src/components/FeatureWrapper.vue
+++ b/src/components/FeatureWrapper.vue
@@ -1,0 +1,55 @@
+<template>
+	<component
+		:is="computedComponent"
+	>
+		<slot
+			v-if="!isDisabled && mode !== 'hide'"
+			:disabled="isDisabled && mode === 'disable'
+		">
+		</slot>
+	</component
+		
+	>
+</template>
+
+<script setup>
+import { computed, inject } from 'vue';
+
+const disabledFeatures = inject('disabledFeatures');
+
+const { feature, mode, blockMessage } = defineProps({
+	feature: {
+		type: String,
+		required: true,
+	},
+	mode: {
+		type: String,
+		default: 'hide',
+		validator: (value) => ['hide', 'disable', 'overlay'].includes(value),
+	},
+	blockMessage: {
+		type: String,
+		default: 'Essa funcionalidade está desabilitada.',
+	},
+});
+
+const isDisabled = computed(() => disabledFeatures.includes(feature));
+const computedComponent = computed(() => {
+	if (!isDisabled.value) {
+		return 'template';
+	}
+
+	switch (mode) {
+		case 'hide':
+			return 'template';
+		case 'overlay':
+			return 'cds-overlay';
+		default:
+			return 'template';
+	}
+});
+</script>
+
+<style lang="scss" scoped>
+/* Your component styles go here */
+</style>

--- a/src/components/__tests__/FeatureWrapper.spec.js
+++ b/src/components/__tests__/FeatureWrapper.spec.js
@@ -25,8 +25,6 @@ describe('FeatureWrapper', () => {
 			},
 		});
 
-		console.log(wrapper.html());
-
 		expect(wrapper.text()).toBe('');
 	});
 

--- a/src/components/__tests__/FeatureWrapper.spec.js
+++ b/src/components/__tests__/FeatureWrapper.spec.js
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils';
+import FeatureWrapper from '../FeatureWrapper.vue';
+import { describe, expect, test } from 'vitest';
+
+const defaultComponent = '<div> Test feature </div>';
+
+const componentDefaultSettings = {
+	slots: {
+		default: defaultComponent,
+	},
+};
+
+describe('FeatureWrapper', () => {
+	test('is hidden when feature is disabled and mode is hide', async () => {
+		const wrapper = mount(FeatureWrapper, {
+			...componentDefaultSettings,
+			global: {
+				provide: {
+					disabledFeatures: ['test-feature'],
+				},
+			},
+			props: {
+				feature: 'test-feature',
+				mode: 'hide',
+			},
+		});
+
+		console.log(wrapper.text());
+		expect(wrapper.text()).toBe('');
+	});
+
+	test('is disabled when feature is disabled and mode is disable', async () => {
+		const wrapper = mount(FeatureWrapper, {
+			slots: {
+				default: '<div> Test feature {{ disabled }} </div>',
+			},
+			global: {
+				provide: {
+					disabledFeatures: ['test-feature'],
+				},
+			},
+			props: {
+				feature: 'test-feature',
+				mode: 'disable',
+			},
+		});
+
+		console.log(wrapper.html());
+
+		// expect(wrapper.text()).toBe(defaultComponent);
+	});
+});

--- a/src/components/__tests__/FeatureWrapper.spec.js
+++ b/src/components/__tests__/FeatureWrapper.spec.js
@@ -25,14 +25,15 @@ describe('FeatureWrapper', () => {
 			},
 		});
 
-		console.log(wrapper.text());
+		console.log(wrapper.html());
+
 		expect(wrapper.text()).toBe('');
 	});
 
 	test('is disabled when feature is disabled and mode is disable', async () => {
 		const wrapper = mount(FeatureWrapper, {
 			slots: {
-				default: '<div> Test feature {{ disabled }} </div>',
+				default: '<div> Component is disabled: {{ disabled }} </div>',
 			},
 			global: {
 				provide: {
@@ -47,6 +48,6 @@ describe('FeatureWrapper', () => {
 
 		console.log(wrapper.html());
 
-		// expect(wrapper.text()).toBe(defaultComponent);
+		expect(wrapper.text()).toBe('Component is disabled: true');
 	});
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@
 import RequestProvider from './RequestProvider.vue';
 import RequestObserver from './RequestObserver.vue';
 import RequestSelect from './RequestSelect.vue';
+import FeatureWrapper from './FeatureWrapper.vue';
 /** -------*/
 
 /** Utils */
@@ -16,11 +17,15 @@ import {
 
 
 export default {
-    install(app: any) {
+    install(app: any, options: any) {
         app.component('ShowRequestProvider', RequestProvider);
         app.component('ShowRequestObserver', RequestObserver);
         app.component('ShowRequestSelect', RequestSelect);
-
+        app.component('ShowFeatureWrapper', FeatureWrapper);
+        
+        if (options && options.disabledFeatures) {
+            app.provide('disabledFeatures', options.disabledFeatures);
+        }
 
         const utils = {
             $showConvertKeysToCamelCase: convertKeysToCamelCase,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,4 +56,8 @@ export default defineConfig({
 			"@": fileURLToPath(new URL("./src", import.meta.url)),
 		},
 	},
+	test: {
+		globals: true,
+		environment: 'jsdom',
+	},
 })


### PR DESCRIPTION
Cria componente FeatureWrapper, para esconder elementos com base num array de funcionalidades fornecido no momento da instanciação do plugin.

### Testando

- Analise e execute os testes unitários;
- Instancie o plugin em um projeto e adicione um array de funcionalidades desabilitadas (`disabledFeatures`) às configurações base;
- Encapsule algum elemento do template com a tag `<ShowFeatureWrapper feature="<nomeDaFuncionalidade>">` e verifique que esse elemento não será renderizado na página, inclusive não estando visível no DOM;
- Caso deseje gerenciar o que acontece com o componente quando ele está desabilitado, utilize a prop `mode` com o valor `disable`, isso fará com que o componente exponha, via slot, a variável `disabled`, que terá valor `true`, caso a funcionalidade esteja desabilitada.