### PR TITLE
feat: implementa composable para o useDialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sysvale/show",
-	"version": "1.9.0",
+	"version": "1.10.0",
 	"description": "A set of components used at Sysvale",
 	"repository": {
 		"type": "git",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ import FeatureWrapper from './FeatureWrapper.vue';
 
 /** Composables */
 import { useRequest } from '@/composables/useRequest';
+import { useDialog } from '@/composables/useDialog';
 /* -------*/
 
 /** Utils */
@@ -24,7 +25,7 @@ import {
 } from '../utils';
 /* -------*/
 
-export { useRequest };
+export { useRequest, useDialog };
 
 export default {
     install(app: any, options = {

--- a/src/composables/useDialog.ts
+++ b/src/composables/useDialog.ts
@@ -1,0 +1,113 @@
+import { ref, readonly, shallowRef, h, render, type Ref, getCurrentInstance, defineComponent, resolveComponent } from 'vue';
+
+interface DialogOptions {
+	title: string;
+	description: string;
+	variant: string;
+	okButtonText: string;
+	cancelButtonText: string;
+	actionButtonVariant: string;
+	onOk: () => void;
+	onCancel: () => void;
+}
+
+export function useDialog() {
+	const instance = getCurrentInstance();
+	const appContext = instance?.appContext;
+
+	const isVisible: Ref<boolean> = ref(false);
+
+	const defaultOptions: DialogOptions = {
+		title: 'Confirmação de exclusão',
+		description: 'Deseja realmente apagar este registro? Essa ação é irreversível.',
+		variant: 'warning',
+		okButtonText: 'Sim, apagar',
+		cancelButtonText: 'Cancelar',
+		actionButtonVariant: 'red',
+		onOk: () => {},
+		onCancel: () => {},
+	};
+
+	const options: Ref<DialogOptions> = ref({ ...defaultOptions });
+
+	const container = shallowRef<HTMLElement | null>(null);
+
+	const createContainer = (): void => {
+		if (!container.value) {
+			container.value = document.createElement('div');
+			document.body.appendChild(container.value);
+		}
+	};
+
+	const destroyContainer = (): void => {
+		if (container.value) {
+			render(null, container.value);
+			document.body.removeChild(container.value);
+			container.value = null;
+		}
+	};
+
+	const confirm = (): void => {
+		options.value.onOk?.();
+		hide();
+	};
+
+	const cancel = (): void => {
+		options.value.onCancel?.();
+		hide();
+	};
+
+	const show = (opts: Partial<DialogOptions>): void => {
+		options.value = { ...defaultOptions, ...opts };
+		createContainer();
+		renderDialog();
+		isVisible.value = true;
+	};
+
+	const hide = (): void => {
+		isVisible.value = false;
+		destroyContainer();
+	};
+
+	const renderDialog = (): void => {
+		if (!container.value) return;
+
+		const dialog = defineComponent({
+			setup() {
+			return () =>
+				h(resolveComponent('CdsDialogModal'), {
+					modelValue: isVisible.value,
+					'update:modelValue': (value: boolean) => {
+						isVisible.value = value;
+						if (!value) cancel();
+					},
+					variant: options.value.variant,
+					title: options.value.title,
+					description: options.value.description,
+					okButtonText: options.value.okButtonText,
+					cancelButtonText: options.value.cancelButtonText,
+					actionButtonVariant: options.value.actionButtonVariant,
+					onOk: confirm,
+					onCancel: cancel,
+				});
+			},
+		});
+
+		const vnode = h(dialog);
+
+		if (appContext) {
+			vnode.appContext = appContext;
+		}
+
+		render(vnode, container.value);
+	};
+
+	return {
+		show,
+		hide,
+		confirm,
+		cancel,
+		isVisible: readonly(isVisible),
+		options: readonly(options),
+	};
+}


### PR DESCRIPTION
Composable para utilização do `DialogModal` do Cuida através de uma API programática

## Importação
```javascript
import { useDialog } from './useDialog';
```

## Inicialização
```javascript
const dialog = useDialog();
```

## 🎯 Métodos Principais

### `show(options: DialogOptions)`
Abre o diálogo com as opções especificadas.

**Parâmetros:**
```typescript
interface DialogOptions {
  title?: string;               // Título (padrão: "Confirmação de exclusão")
  description?: string;         // Mensagem descritiva
  variant?: string;             // Estilo visual ('warning', 'error')
  okButtonText?: string;        // Texto do botão OK (padrão: "Sim, apagar")
  cancelButtonText?: string;    // Texto do botão Cancelar (padrão: "Cancelar")
  actionButtonVariant?: string; // Variante do botão (padrão: 'red')
  onOk?: () => void;           // Callback de confirmação
  onCancel?: () => void;       // Callback de cancelamento
}
```

### `hide()`
Fecha o diálogo programaticamente.

### `confirm()`
Executa a ação de confirmação.

### `cancel()`
Executa a ação de cancelamento.

## 💡 Exemplo de Uso
```javascript
const dialog = useDialog();

// Abrir diálogo
dialog.show({
  title: 'Confirmar ação',
  description: 'Tem certeza que deseja prosseguir?',
  onOk: () => console.log('Ação confirmada'),
  onCancel: () => console.log('Ação cancelada')
});

// Fechar manualmente
dialog.hide();
```